### PR TITLE
Added connection-refused event

### DIFF
--- a/iris-rpc.js
+++ b/iris-rpc.js
@@ -493,6 +493,9 @@ function Interface(options) {
 
         if(err.code != 'ECONNREFUSED')
             self.emitToListeners('disconnect', stream.uuid, stream);
+        else 
+            self.emitToListeners('connection-refused', stream.uuid, stream);
+
         pendingCleanup(stream);
         // console.log(("RPC DISCONNECTING STREAM "+stream.uuid).green.bold);
         delete self.streams[stream.uuid];


### PR DESCRIPTION
Useful for scenarios where a client may want to perform specific actions or fallback to another service or communication mechanism if server connection cannot be established,